### PR TITLE
feat: remove clock param from opmove(), enabled by TreeReplica in crdt_tree 0.0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ repository = "https://github.com/maidsafe/brb_dt_tree"
 edition = "2018"
 
 [dependencies]
-crdt_tree = "0.0.8"
-brb = "1.0.2"
-serde = "1.0.120"
+crdt_tree = "0.0.12"
+brb = "1.0.4"
+serde = "1.0.123"
 thiserror = "1.0.23"
 
 [dev-dependencies]


### PR DESCRIPTION
This change also updates (and simplifies somewhat) the tests


**Motivation:**
I need this for my fork of brb_tree_qp2p that uses a tree.  Also the code is just cleaner/simpler.